### PR TITLE
idiomatic bash shebang

### DIFF
--- a/shell-samples/backup-alert-conditions.sh
+++ b/shell-samples/backup-alert-conditions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## Set the NEW_RELIC_APIKEY env here if needed by comment out below export cmd
 #export NEW_RELIC_APIKEY="xxx-xxxx-xxx"

--- a/shell-samples/backup-dashboards.sh
+++ b/shell-samples/backup-dashboards.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## Can set the NEW_RELIC_APIKEY env here by comment out below export cmd
 #export NEW_RELIC_APIKEY="xxx-xxxx-xxx"

--- a/shell-samples/backup-monitors.sh
+++ b/shell-samples/backup-monitors.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## Can set the NEW_RELIC_APIKEY env here by comment out below export cmd
 #export NEW_RELIC_APIKEY="xxx-xxxx-xxx"

--- a/shell-samples/restore-monitors.sh
+++ b/shell-samples/restore-monitors.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 noNRKey="No NEW_RELIC_APIKEY detected."
 noNRKey=${noNRKey}"\n\n"


### PR DESCRIPTION
Use `#!/usr/bin/env bash` as bash shebang for better portability.