### PR TITLE
add additional dashboard structure values

### DIFF
--- a/newrelic/dashboards.go
+++ b/newrelic/dashboards.go
@@ -21,8 +21,17 @@ import (
 )
 
 type Dashboard struct {
-	// ID    *int64  `json:"id,omitempty"`
-	// Title *string `json:"title,omitempty"`
+	ID          *int64  `json:"id,omitempty"`
+	Title       *string `json:"title,omitempty"`
+	Description *string `json:"description,omitempty"`
+	Icon        *string `json:"icon,omitempty"`
+	//created_at
+	//updated_at
+	Visibility *string `json:"visibility,omitempty"`
+	Editable   *string `json:"editable,omitempty"`
+	UIURL      *string `json:"ui_url,omitempty"`
+	APIURL     *string `json:"api_url,omitempty"`
+	OwnerEmail *string `json:"owner_email,omitempty"`
 }
 
 type DashboardList struct {
@@ -34,6 +43,10 @@ type DashboardListOptions struct {
 }
 
 type DashboardService service
+
+type CreateDashboardResponse struct {
+	Dashboard *Dashboard `json:"dashboard,omitempty"`
+}
 
 func (s *DashboardService) ListAll(ctx context.Context, opt *DashboardListOptions) (*Response, []byte, error) {
 	u, err := addOptions("dashboards.json", opt)


### PR DESCRIPTION
I am trying to use your CLI as a API for newrelic as you do alot of the legwork already.  I think you are selling yourself short on just calling this project `newrelic-cli` it also does a good job being used as a golang API for talking to newrelic since you separated the CLI and the API portions.